### PR TITLE
Add support for giving TLS auth name instead of pinset, and testing whether resolver supports qname minimisation

### DIFF
--- a/check-dns-with-getdns.c
+++ b/check-dns-with-getdns.c
@@ -425,10 +425,13 @@ main(int argc, char **argv)
                getdns_pretty_print_dict(getdns_context_get_api_information
                                         (this_context)));
     }
+    process_return =
+        getdns_dict_set_int(extensions, "return_both_v4_and_v6",
+                            GETDNS_EXTENSION_TRUE);
 
     /* Make the call */
     getdns_return_t dns_request_return =
-        getdns_address_sync(this_context, lookup_name,
+        getdns_general_sync(this_context, lookup_name, GETDNS_RRTYPE_AAAA,
                             extensions, &this_response);
     if (dns_request_return != GETDNS_RETURN_GOOD) {
         sprintf(msgbuf, "Error %s (%d) when resolving %s at %s",

--- a/check-dns-with-getdns.c
+++ b/check-dns-with-getdns.c
@@ -689,7 +689,24 @@ main(int argc, char **argv)
         error(msgbuf);
     }
     /* sprintf(msgbuf, "From %s got %s", server_name, msgbuf); TODO does not work */
-    success(msgbuf);
+    switch (exit_status)
+    {
+    case STATE_OK:
+        success(msgbuf);
+        break;
+
+    case STATE_WARNING:
+        warning(msgbuf);
+        break;
+
+    case STATE_CRITICAL:
+        error(msgbuf);
+        break;
+
+    case STATE_UNKNOWN:
+        internal_error(msgbuf);
+        break;
+    }
     getdns_dict_destroy(this_response);
 
     /* Clean up */


### PR DESCRIPTION
John is working on monitoring for DNSprivacy test servers, and want to to able to use TLS auth name instead of pinset, and also to test whether the resolver supports qname minimisation.

Any interest?